### PR TITLE
Fix fragment not inflated issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -25,10 +25,10 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:design:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/app/src/androidTest/java/com/raymond/viewstubfragmentdemo/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/raymond/viewstubfragmentdemo/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package com.raymond.viewstubfragmentdemo
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/main/java/com/raymond/viewstubfragmentdemo/BaseViewStubFragment.kt
+++ b/app/src/main/java/com/raymond/viewstubfragmentdemo/BaseViewStubFragment.kt
@@ -1,13 +1,13 @@
 package com.raymond.viewstubfragmentdemo
 
-import android.support.v4.app.Fragment
-import android.support.annotation.CallSuper
-import android.support.annotation.LayoutRes
-import android.view.ViewStub
 import android.os.Bundle
-import android.view.ViewGroup
+import androidx.annotation.CallSuper
+import androidx.annotation.LayoutRes
+import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
+import android.view.ViewStub
 import android.widget.ProgressBar
 
 

--- a/app/src/main/java/com/raymond/viewstubfragmentdemo/BaseViewStubFragment.kt
+++ b/app/src/main/java/com/raymond/viewstubfragmentdemo/BaseViewStubFragment.kt
@@ -15,14 +15,19 @@ abstract class BaseViewStubFragment : Fragment() {
     private var mSavedInstanceState: Bundle? = null
     private var hasInflated = false
     private var mViewStub: ViewStub? = null
+    private var visible = false
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         val view = inflater.inflate(R.layout.fragment_viewstub, container, false)
         mViewStub = view.findViewById(R.id.fragmentViewStub) as ViewStub
         mViewStub!!.layoutResource = getViewStubLayoutResource()
         mSavedInstanceState = savedInstanceState
 
-        if (userVisibleHint && !hasInflated) {
+        if (visible && !hasInflated) {
             val inflatedView = mViewStub!!.inflate()
             onCreateViewAfterViewStubInflated(inflatedView, mSavedInstanceState)
             afterViewStubInflated(view)
@@ -31,7 +36,10 @@ abstract class BaseViewStubFragment : Fragment() {
         return view
     }
 
-    protected abstract fun onCreateViewAfterViewStubInflated(inflatedView: View, savedInstanceState: Bundle?)
+    protected abstract fun onCreateViewAfterViewStubInflated(
+        inflatedView: View,
+        savedInstanceState: Bundle?
+    )
 
     /**
      * The layout ID associated with this ViewStub
@@ -49,19 +57,31 @@ abstract class BaseViewStubFragment : Fragment() {
     protected fun afterViewStubInflated(originalViewContainerWithViewStub: View?) {
         hasInflated = true
         if (originalViewContainerWithViewStub != null) {
-            val pb = originalViewContainerWithViewStub.findViewById<ProgressBar>(R.id.inflateProgressbar)
+            val pb =
+                originalViewContainerWithViewStub.findViewById<ProgressBar>(R.id.inflateProgressbar)
             pb.visibility = View.GONE
         }
     }
 
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
+    override fun onResume() {
+        super.onResume()
 
-        if (isVisibleToUser && mViewStub != null && !hasInflated) {
+        visible = true
+        if (mViewStub != null && !hasInflated) {
             val inflatedView = mViewStub!!.inflate()
             onCreateViewAfterViewStubInflated(inflatedView, mSavedInstanceState)
             afterViewStubInflated(view)
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        hasInflated = false
+    }
+
+    override fun onPause() {
+        super.onPause()
+        visible = false
     }
 
     // Thanks to Noa Drach, this will fix the orientation change problem

--- a/app/src/main/java/com/raymond/viewstubfragmentdemo/FragmentAdapter.kt
+++ b/app/src/main/java/com/raymond/viewstubfragmentdemo/FragmentAdapter.kt
@@ -1,9 +1,9 @@
 package com.raymond.viewstubfragmentdemo
 
 import android.os.Bundle
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentManager
-import android.support.v4.app.FragmentStatePagerAdapter
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentStatePagerAdapter
 
 class FragmentAdapter(fm: FragmentManager) : FragmentStatePagerAdapter(fm) {
 

--- a/app/src/main/java/com/raymond/viewstubfragmentdemo/MainActivity.kt
+++ b/app/src/main/java/com/raymond/viewstubfragmentdemo/MainActivity.kt
@@ -1,9 +1,9 @@
 package com.raymond.viewstubfragmentdemo
 
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.support.design.widget.TabLayout
-import android.support.v4.view.ViewPager
+import com.google.android.material.tabs.TabLayout
+import androidx.viewpager.widget.ViewPager
 
 class MainActivity : AppCompatActivity() {
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -7,28 +7,28 @@
         android:layout_height="match_parent"
         tools:context=".MainActivity">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 app:title="ViewStubFragmentDemo"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
-        <android.support.design.widget.TabLayout
+        <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tabLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
-        </android.support.design.widget.TabLayout>
-    </android.support.design.widget.AppBarLayout>
+        </com.google.android.material.tabs.TabLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
-    <android.support.v4.view.ViewPager
+    <androidx.viewpager.widget.ViewPager
             android:id="@+id/viewPager"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    </android.support.v4.view.ViewPager>
+    </androidx.viewpager.widget.ViewPager>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_heavy.xml
+++ b/app/src/main/res/layout/fragment_heavy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -15,4 +15,4 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Thanks for your demo and your article helped me a lot. I found an issue when open a fragment from any of the viewPager fragments then go back I noticed that the progress is still loading and the view not inflated.
let's say an example:
we have fragments a,b & c
inside a there's a button to open another fragment d
when clicking on the button to open the fragment d
fragments a,b & get destroyed without going to => onDetach() method
so the variable "hasInflated" is still equals "true"
when going back to the fragment a 
the =>onCreateView() get called without inflating the layout 
and also when going to =>onResume() the layout not inflated
the solution is setting "hasInflated" = false in onDestroyView()
--------------------------------------------------------------------------------
the other part of the pull request is handling  getUserVisibleHint () is deprecated